### PR TITLE
feat(login) : 로그인 기능 추가

### DIFF
--- a/src/main/java/com/yeolsimee/moneysaving/app/user/controller/LoginController.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/user/controller/LoginController.java
@@ -1,0 +1,40 @@
+package com.yeolsimee.moneysaving.app.user.controller;
+
+import com.yeolsimee.moneysaving.app.common.response.service.*;
+import com.yeolsimee.moneysaving.app.user.dto.*;
+import lombok.*;
+import org.springframework.http.*;
+import org.springframework.security.authentication.*;
+import org.springframework.security.core.*;
+import org.springframework.security.core.context.*;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * packageName    : com.yeolsimee.moneysaving.app.user.controller
+ * fileName       : LoginController
+ * author         : jeon-eunseong
+ * date           : 2023/03/01
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2023/03/01        jeon-eunseong       최초 생성
+ */
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class LoginController {
+
+    private final AuthenticationManager authenticationManager;
+
+    private final ResponseService responseService;
+
+    @PostMapping("/signin")
+    public ResponseEntity<?> authenticateUser(@RequestBody LoginDto loginDto){
+        Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(
+                loginDto.getUsername(), loginDto.getPassword()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        return ResponseEntity.ok(responseService.getSuccessResult());
+    }
+}

--- a/src/main/java/com/yeolsimee/moneysaving/app/user/dto/LoginDto.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/user/dto/LoginDto.java
@@ -1,0 +1,23 @@
+package com.yeolsimee.moneysaving.app.user.dto;
+
+import lombok.*;
+
+/**
+ * packageName    : com.yeolsimee.moneysaving.app.user.dto
+ * fileName       : LoginDto
+ * author         : jeon-eunseong
+ * date           : 2023/03/01
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2023/03/01        jeon-eunseong       최초 생성
+ */
+
+@Data
+public class LoginDto {
+
+    private String username;
+
+    private String password;
+}

--- a/src/main/java/com/yeolsimee/moneysaving/app/user/entity/Role.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/user/entity/Role.java
@@ -1,0 +1,30 @@
+package com.yeolsimee.moneysaving.app.user.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+/**
+ * packageName    : com.yeolsimee.moneysaving.app.user
+ * fileName       : Role
+ * author         : jeon-eunseong
+ * date           : 2023/03/01
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2023/03/01        jeon-eunseong       최초 생성
+ */
+@Setter
+@Getter
+@Entity
+@Table(name = "roles")
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(length = 60)
+    private String name;
+}

--- a/src/main/java/com/yeolsimee/moneysaving/app/user/entity/User.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/user/entity/User.java
@@ -1,9 +1,13 @@
 package com.yeolsimee.moneysaving.app.user.entity;
 
 import lombok.*;
+import org.springframework.security.core.*;
+import org.springframework.security.core.authority.*;
+import org.springframework.security.core.userdetails.*;
 
 import javax.persistence.*;
 import java.util.*;
+import java.util.stream.*;
 
 /**
  * packageName    : com.yeolsimee.moneysaving.app.user
@@ -16,13 +20,13 @@ import java.util.*;
  * -----------------------------------------------------------
  * 2023/03/01        jeon-eunseong       최초 생성
  */
-@Data
+@Getter
 @Entity
 @Table(name = "users", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"username"}),
         @UniqueConstraint(columnNames = {"email"})
 })
-public class User {
+public class User implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,4 +41,29 @@ public class User {
             joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id"),
             inverseJoinColumns = @JoinColumn(name = "role_id", referencedColumnName = "id"))
     private Set<Role> roles;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return this.roles.stream().map((role)-> new SimpleGrantedAuthority(role.getName())).collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/src/main/java/com/yeolsimee/moneysaving/app/user/entity/User.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/user/entity/User.java
@@ -1,0 +1,40 @@
+package com.yeolsimee.moneysaving.app.user.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.*;
+
+/**
+ * packageName    : com.yeolsimee.moneysaving.app.user
+ * fileName       : User
+ * author         : jeon-eunseong
+ * date           : 2023/03/01
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2023/03/01        jeon-eunseong       최초 생성
+ */
+@Data
+@Entity
+@Table(name = "users", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"username"}),
+        @UniqueConstraint(columnNames = {"email"})
+})
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private String name;
+    private String username;
+    private String email;
+    private String password;
+
+    @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @JoinTable(name = "user_roles",
+            joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id", referencedColumnName = "id"))
+    private Set<Role> roles;
+}

--- a/src/main/java/com/yeolsimee/moneysaving/app/user/repository/RoleRepository.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/user/repository/RoleRepository.java
@@ -1,0 +1,18 @@
+package com.yeolsimee.moneysaving.app.user.repository;
+
+import com.yeolsimee.moneysaving.app.user.entity.*;
+import org.springframework.data.jpa.repository.*;
+
+/**
+ * packageName    : com.yeolsimee.moneysaving.app.user.repository
+ * fileName       : RoleRepository
+ * author         : jeon-eunseong
+ * date           : 2023/03/01
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2023/03/01        jeon-eunseong       최초 생성
+ */
+public interface RoleRepository extends JpaRepository<Role, Long> {
+}

--- a/src/main/java/com/yeolsimee/moneysaving/app/user/repository/UserRepository.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/user/repository/UserRepository.java
@@ -1,0 +1,21 @@
+package com.yeolsimee.moneysaving.app.user.repository;
+
+import com.yeolsimee.moneysaving.app.user.entity.*;
+import org.springframework.data.jpa.repository.*;
+
+import java.util.*;
+
+/**
+ * packageName    : com.yeolsimee.moneysaving.app.user.repository
+ * fileName       : UserRepository
+ * author         : jeon-eunseong
+ * date           : 2023/03/01
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2023/03/01        jeon-eunseong       최초 생성
+ */
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/yeolsimee/moneysaving/app/user/service/CustomUserDetailService.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/user/service/CustomUserDetailService.java
@@ -1,0 +1,32 @@
+package com.yeolsimee.moneysaving.app.user.service;
+
+import com.yeolsimee.moneysaving.app.user.entity.User;
+import com.yeolsimee.moneysaving.app.user.repository.*;
+import lombok.*;
+import org.springframework.security.core.userdetails.*;
+import org.springframework.stereotype.*;
+
+/**
+ * packageName    : com.yeolsimee.moneysaving.app.user.service
+ * fileName       : CustomUserDetailService
+ * author         : jeon-eunseong
+ * date           : 2023/03/01
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2023/03/01        jeon-eunseong       최초 생성
+ */
+@Service("customUserDetailService")
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new UsernameNotFoundException("Username Not Found"));
+
+        return user;
+    }
+}


### PR DESCRIPTION
#10 로그인 기능 구현
###  📌 요약
- POST localhost:8080/api/v1/signin 경로로 로그인 로직 추가
- 현재 로그인 기능만 작업했으므로 BCryptPasswordEncoder를 통해 비밀번호 생성하여 사용자를 해야함
- url 구성에 대해 논의 후 경로 변경 예정

### 📕 무엇을 작업하셨나요?
- [ ] 버그 수정
- [x] 기능 개발
- [ ] 리팩터링
- [ ] 빌드 및 환경설정 관련 작업
- [ ] 그 외의 경우 간략히 기술해주세요

### 📖 변경사항
- Spring security 5.7버전 이후부터 WebSecurityConfigurerAdapter가 deprecated 됨으로써, FilterChain 방식으로 변경
- 현재 Spring security 5.7버전까지는 antMatcher 사용중이지만, 이후 버전부턴 requestMatcher로 변경 요망 (Spring boot 3 업그레이드 시)


### ✅ 체크리스트
- [ ] 환경변수를 임의로 수정하지 않았나요?
- [ ] 불필요한 로그를 지우셨나요?