### PR TITLE
fix(login): 로그인 시 세션 저장 정책 오류 수정

### DIFF
--- a/src/main/java/com/yeolsimee/moneysaving/config/SecurityConfig.java
+++ b/src/main/java/com/yeolsimee/moneysaving/config/SecurityConfig.java
@@ -7,7 +7,6 @@ import org.springframework.security.authentication.*;
 import org.springframework.security.config.annotation.authentication.configuration.*;
 import org.springframework.security.config.annotation.web.builders.*;
 import org.springframework.security.config.annotation.web.configuration.*;
-import org.springframework.security.config.http.*;
 import org.springframework.security.core.userdetails.*;
 import org.springframework.security.crypto.bcrypt.*;
 import org.springframework.security.crypto.password.*;
@@ -40,8 +39,6 @@ public class SecurityConfig {
                 .cors().configurationSource(corsConfigurationSource())
                 .and()
                 .csrf().disable()
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
                 .authorizeHttpRequests((authorize) ->
                     authorize.antMatchers(HttpMethod.GET, "/api/v1/**").permitAll()
                             .antMatchers(HttpMethod.POST, "/api/v1/signin").permitAll()


### PR DESCRIPTION
###  📌 요약
- #14 세션 정책 오류로 인해 로그인 세션 생성정책을 제거

### 📕 무엇을 작업하셨나요?
- [x] 버그 수정
- [ ] 기능 개발
- [ ] 리팩터링
- [ ] 빌드 및 환경설정 관련 작업
- [ ] 그 외의 경우 간략히 기술해주세요

### 📖 변경사항
- SessionCreationPolicy.STATELESS 제거
