### PR TITLE
(bugfix/withdraw) 탈퇴시 데이터 삭제하는 방식으로 변경

### DIFF
--- a/src/main/java/com/yeolsimee/moneysaving/app/category/repository/CategoryRepository.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/category/repository/CategoryRepository.java
@@ -1,6 +1,7 @@
 package com.yeolsimee.moneysaving.app.category.repository;
 
 import com.yeolsimee.moneysaving.app.category.entity.Category;
+import com.yeolsimee.moneysaving.app.user.entity.*;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.lang.*;
@@ -17,4 +18,5 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     @Query("select c from Category c where c.id = :categoryId and c.user.id = :userId")
     Optional<Category> findByIdAndUserId(long categoryId, long userId);
 
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/yeolsimee/moneysaving/app/routine/repository/RoutineRepository.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/routine/repository/RoutineRepository.java
@@ -22,5 +22,7 @@ public interface RoutineRepository extends JpaRepository<Routine, Long>, Routine
 
     List<Routine> findByUserId(Long userId);
 
+    void deleteAllByUserId(Long userId);
+
 
 }

--- a/src/main/java/com/yeolsimee/moneysaving/app/routine/repository/RoutineRepository.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/routine/repository/RoutineRepository.java
@@ -2,6 +2,7 @@ package com.yeolsimee.moneysaving.app.routine.repository;
 
 import com.yeolsimee.moneysaving.app.routine.entity.Routine;
 import com.yeolsimee.moneysaving.app.routine.entity.WeekType;
+import com.yeolsimee.moneysaving.app.user.entity.*;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -9,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface RoutineRepository extends JpaRepository<Routine, Long>, RoutineRepositoryCustom {
+
     Optional<Routine> findByIdAndUserId(Long routineId, Long userId);
 
     @Query("select r from Routine r where r.user.id = :userId and r.routineStartDate <= :routineDay and r.routineEndDate >= :routineDay and r.alarmStatus = 'ON'")
@@ -22,7 +24,6 @@ public interface RoutineRepository extends JpaRepository<Routine, Long>, Routine
 
     List<Routine> findByUserId(Long userId);
 
-    void deleteAllByUserId(Long userId);
-
+    void deleteByUser(User user);
 
 }

--- a/src/main/java/com/yeolsimee/moneysaving/app/user/controller/UserController.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/user/controller/UserController.java
@@ -1,16 +1,12 @@
 package com.yeolsimee.moneysaving.app.user.controller;
 
 import com.google.firebase.auth.*;
-import com.yeolsimee.moneysaving.app.common.response.*;
 import com.yeolsimee.moneysaving.app.common.response.service.*;
-import com.yeolsimee.moneysaving.app.routine.repository.*;
 import com.yeolsimee.moneysaving.app.user.dto.*;
 import com.yeolsimee.moneysaving.app.user.entity.*;
-import com.yeolsimee.moneysaving.app.user.repository.*;
 import com.yeolsimee.moneysaving.app.user.service.*;
 import lombok.*;
 import lombok.extern.slf4j.*;
-import org.apache.commons.lang3.*;
 import org.springframework.http.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -53,10 +49,6 @@ public class UserController {
 
         if(Objects.isNull(user)){
             user = userService.signUp(uid);
-        }
-
-        if(StringUtils.equals("Y", user.getDeleteYn())){
-            return ResponseEntity.ok(responseService.getSuccessResult(ResponseMessage.WITHDRAW_USER.getMessage()));
         }
 
         return ResponseEntity.ok(responseService.getSingleResult(UserInfoResponse.of(user)));

--- a/src/main/java/com/yeolsimee/moneysaving/app/user/entity/User.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/user/entity/User.java
@@ -64,10 +64,6 @@ public class User extends BaseEntity implements UserDetails  {
     @OneToMany
     private List<Category> categoryList;
 
-    @Column(nullable = false)
-    @Builder.Default
-    private String deleteYn = "N";
-
     public User(String name, String username, Role role) {
         this.name = name;
         this.username = username;
@@ -110,7 +106,4 @@ public class User extends BaseEntity implements UserDetails  {
         this.isNewUser = isNewUser;
     }
 
-    public void changeDeleteYn(String deleteYn){
-        this.deleteYn = deleteYn;
-    }
 }

--- a/src/main/java/com/yeolsimee/moneysaving/app/user/service/UserService.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/user/service/UserService.java
@@ -90,6 +90,7 @@ public class UserService implements UserDetailsService {
         return UserInfoResponse.of(user);
     }
 
+    @Transactional
     public void withdraw(User user) {
         List<Routine> routineList = routineRepository.findByUserId(user.getId());
         routineList.forEach(routine -> routineHistoryRepository.deleteByRoutineId(routine.getId()));

--- a/src/main/java/com/yeolsimee/moneysaving/app/user/service/UserService.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/user/service/UserService.java
@@ -88,7 +88,6 @@ public class UserService implements UserDetailsService {
         List<Routine> routineList = routineRepository.findByUserId(user.getId());
         routineList.forEach(routine -> routine.changeRoutineDeleteYN("Y"));
         routineRepository.saveAll(routineList);
-        user.changeDeleteYn("Y");
         userRepository.save(user);
     }
 
@@ -97,7 +96,6 @@ public class UserService implements UserDetailsService {
         FirebaseToken firebaseToken = firebaseAuth.verifyIdToken(jwt);
         String uid = firebaseToken.getUid();
         User user = getUserByUid(uid);
-        user.changeDeleteYn("N");
         userRepository.save(user);
 
         List<Routine> routineList = routineRepository.findByUserId(user.getId());

--- a/src/main/java/com/yeolsimee/moneysaving/app/user/service/UserService.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/user/service/UserService.java
@@ -67,8 +67,10 @@ public class UserService implements UserDetailsService {
 
     public Authentication getAuthentication(String uid){
 
-        User user = userRepository.findByUsername(uid).orElseThrow();
-
+        User user = getUserByUid(uid);
+        if(Objects.isNull(user)){
+            throw new EntityNotFoundException(ResponseMessage.AUTH_USER);
+        }
         return new UsernamePasswordAuthenticationToken(user, "", user.getAuthorities());
     }
 

--- a/src/main/java/com/yeolsimee/moneysaving/app/user/service/UserService.java
+++ b/src/main/java/com/yeolsimee/moneysaving/app/user/service/UserService.java
@@ -1,10 +1,12 @@
 package com.yeolsimee.moneysaving.app.user.service;
 
 import com.google.firebase.auth.*;
+import com.yeolsimee.moneysaving.app.category.repository.*;
 import com.yeolsimee.moneysaving.app.common.exception.*;
 import com.yeolsimee.moneysaving.app.common.response.*;
 import com.yeolsimee.moneysaving.app.routine.entity.*;
 import com.yeolsimee.moneysaving.app.routine.repository.*;
+import com.yeolsimee.moneysaving.app.routinehistory.repository.*;
 import com.yeolsimee.moneysaving.app.user.dto.*;
 import com.yeolsimee.moneysaving.app.user.entity.*;
 import com.yeolsimee.moneysaving.app.user.entity.User;
@@ -37,6 +39,8 @@ public class UserService implements UserDetailsService {
     private final FirebaseAuth firebaseAuth;
     private final UserRepository userRepository;
     private final RoutineRepository routineRepository;
+    private final RoutineHistoryRepository routineHistoryRepository;
+    private final CategoryRepository categoryRepository;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
@@ -88,9 +92,10 @@ public class UserService implements UserDetailsService {
 
     public void withdraw(User user) {
         List<Routine> routineList = routineRepository.findByUserId(user.getId());
-        routineList.forEach(routine -> routine.changeRoutineDeleteYN("Y"));
-        routineRepository.saveAll(routineList);
-        userRepository.save(user);
+        routineList.forEach(routine -> routineHistoryRepository.deleteByRoutineId(routine.getId()));
+        routineRepository.deleteByUser(user);
+        categoryRepository.deleteByUser(user);
+        userRepository.delete(user);
     }
 
     public void recovery(String jwt) throws FirebaseAuthException {

--- a/src/main/java/com/yeolsimee/moneysaving/filter/JwtFilter.java
+++ b/src/main/java/com/yeolsimee/moneysaving/filter/JwtFilter.java
@@ -2,7 +2,6 @@ package com.yeolsimee.moneysaving.filter;
 
 import com.google.firebase.auth.*;
 import com.yeolsimee.moneysaving.app.common.response.*;
-import com.yeolsimee.moneysaving.app.user.entity.*;
 import com.yeolsimee.moneysaving.app.user.service.*;
 import lombok.*;
 import lombok.extern.slf4j.*;
@@ -17,7 +16,6 @@ import org.springframework.web.filter.*;
 import javax.servlet.*;
 import javax.servlet.http.*;
 import java.io.*;
-import java.util.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -48,11 +46,6 @@ public class JwtFilter extends OncePerRequestFilter {
             FirebaseToken verifyIdToken = firebaseAuth.verifyIdToken(jwt);
             String uid = verifyIdToken.getUid();
             Authentication authentication = userService.getAuthentication(uid);
-            User user = (User) authentication.getPrincipal();
-            if(Objects.equals("Y", user.getDeleteYn())){
-                setUnauthorizedResponse(response, ResponseMessage.WITHDRAW_USER.getMessage());
-                return;
-            }
             SecurityContextHolder.getContext().setAuthentication(authentication);
         } catch (FirebaseAuthException e) {
             log.error(e.getMessage());


### PR DESCRIPTION
###  📌 요약
- 회원탈퇴시 루틴 카테고리 히스토리 유저 전부 삭제하는 방식으로 수정 (withdraw 함수 내 delete 관련 함수들이 정상작동인지 테스트 필요)

### 📕 무엇을 작업하셨나요?
- [x] 버그 수정
- [ ] 기능 개발
- [ ] 리팩터링
- [ ] 빌드 및 환경설정 관련 작업
- [ ] 그 외의 경우 간략히 기술해주세요

### 📖 변경사항
- User 테이블 deleteYn 제거

### ✅ 체크리스트
- [ ] 환경변수를 임의로 수정하지 않았나요?
- [ ] 불필요한 로그를 지우셨나요?